### PR TITLE
Install header files in a dedicated subdirectory.

### DIFF
--- a/libzfswrap.pc.in
+++ b/libzfswrap.pc.in
@@ -1,7 +1,7 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@
+includedir=@includedir@/libzfswrap
 
 Name: @PACKAGE_NAME@
 Description: Library to access to a ZFS filesystem without fuse.

--- a/zfswrap/Makefile.am
+++ b/zfswrap/Makefile.am
@@ -1,6 +1,6 @@
 lib_LTLIBRARIES = libzfswrap.la
 
-library_includedir=$(includedir)
+library_includedir=$(includedir)/libzfswrap
 library_include_HEADERS = libzfswrap.h \
 	portable/acl.h \
 	portable/acl_impl.h \


### PR DESCRIPTION
Previously, installing libzfswrap in /usr would result in some of its
header files overwriting ones belonging to glibc (e.g.
/usr/include/stat.h). Just install all headerfiles in a subdirectory and
update the pkgconfig data file accordingly so that they can still be
found by software which needs it.
